### PR TITLE
Upgrade template to php8 + composer2

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -5,9 +5,12 @@
 name: app
 
 # The type of the application to build.
-type: php:7.4
-build:
-    flavor: composer
+type: 'php:8.0'
+
+# Indicate that we want to use composer2, (leave out if you want composer1)
+dependencies:
+    php: 
+        composer/composer: '^2'
 
 # The hooks that will be performed when the package is deployed.
 hooks:


### PR DESCRIPTION
Update to php8
build flavor is composer by default, so no use in listing it
setting it to use composer2